### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-commit.yml
+++ b/.github/workflows/auto-commit.yml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   auto-commit:
+    permissions:
+      contents: write
+      repository: write
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     


### PR DESCRIPTION
Potential fix for [https://github.com/sajidabbas3156/Olalaundry-prod/security/code-scanning/2](https://github.com/sajidabbas3156/Olalaundry-prod/security/code-scanning/2)

To fix this issue, we should add the explicit `permissions:` block to the workflow or to the job (the latter is better if only the job uses those permissions). For this workflow, the job "auto-commit" performs commits and pushes (`contents: write`) and uses `repository-dispatch` (`repository: write`). No other explicit permissions appear to be needed. 

The best way to fix the problem is to add a `permissions:` block to the `auto-commit` job, immediately above `runs-on:` at line 15. The block should specify:
```yaml
permissions:
  contents: write
  repository: write
```
This limits the GITHUB_TOKEN to just the write permissions needed for git pushes and repository dispatch. No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
